### PR TITLE
Add unit tests for utility methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# The Grids Project
+
+This repository contains a small arcade-based prototype. Automated tests have been added under the `tests/` directory.
+
+## Running Tests
+
+Install dependencies (e.g. `arcade` and `pytest`) and run:
+
+```bash
+pytest
+```
+
+This will execute all unit tests.

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,0 +1,27 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from unittest.mock import patch
+import arcade
+from grids import GridsGame, CELL_SIZE, GRID_WIDTH, GRID_HEIGHT, ROWS, COLUMNS
+
+@pytest.fixture
+def game():
+    with patch('arcade.Window.__init__', return_value=None):
+        g = GridsGame()
+    return g
+
+def test_get_clicked_cell_inside(game):
+    # Choose coordinates well within the grid
+    x = CELL_SIZE * 2 + 10
+    y = CELL_SIZE * 3 + 5
+    assert game.get_clicked_cell(x, y) == (3, 2)
+
+def test_get_clicked_cell_outside(game):
+    assert game.get_clicked_cell(-1, 10) is None
+    assert game.get_clicked_cell(GRID_WIDTH, 10) is None
+    assert game.get_clicked_cell(10, GRID_HEIGHT) is None
+
+def test_manhattan_distance(game):
+    assert game.manhattan_distance((0, 0), (1, 1)) == 2
+    assert game.manhattan_distance((0, 0), (ROWS - 1, COLUMNS - 1)) == (ROWS - 1) + (COLUMNS - 1)


### PR DESCRIPTION
## Summary
- add pytest tests for `get_clicked_cell` and `manhattan_distance`
- provide headless `GridsGame` fixture
- document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430cef883483259b54f063b00f7c74