### PR TITLE
Fix UI rectangle drawing and center button text

### DIFF
--- a/game.py
+++ b/game.py
@@ -128,9 +128,9 @@ class GridsGame(arcade.Window):
         for unit in self.units:
             unit.draw()
         panel_x = GRID_WIDTH + UI_PANEL_WIDTH / 2
-        arcade.draw_lbwh_rectangle_filled(
-            panel_x,
-            SCREEN_HEIGHT / 2,
+        arcade.draw_xywh_rectangle_filled(
+            GRID_WIDTH,
+            0,
             UI_PANEL_WIDTH,
             SCREEN_HEIGHT,
             arcade.color.DARK_SLATE_GRAY,
@@ -138,14 +138,38 @@ class GridsGame(arcade.Window):
         arcade.draw_text(f"Player {self.current_player} - AP: {self.current_action_points}", GRID_WIDTH + 10, SCREEN_HEIGHT - 30, arcade.color.WHITE, 14)
         # Draw buttons
 
-        arcade.draw_lbwh_rectangle_filled(self.end_turn_button['center_x'], self.end_turn_button['center_y'],
-                                self.end_turn_button['width'], self.end_turn_button['height'], arcade.color.GRAY)
-        arcade.draw_text("End Turn", self.end_turn_button['center_x'] - 40, self.end_turn_button['center_y'] - 7,
-                         arcade.color.WHITE, 12)
-        arcade.draw_lbwh_rectangle_filled(self.draw_card_button['center_x'], self.draw_card_button['center_y'],
-                                self.draw_card_button['width'], self.draw_card_button['height'], arcade.color.GRAY)
-        arcade.draw_text("Draw Card", self.draw_card_button['center_x'] - 45, self.draw_card_button['center_y'] - 7,
-                         arcade.color.WHITE, 12)
+        arcade.draw_xywh_rectangle_filled(
+            self.end_turn_button['center_x'] - self.end_turn_button['width'] / 2,
+            self.end_turn_button['center_y'] - self.end_turn_button['height'] / 2,
+            self.end_turn_button['width'],
+            self.end_turn_button['height'],
+            arcade.color.GRAY,
+        )
+        arcade.draw_text(
+            "End Turn",
+            self.end_turn_button['center_x'],
+            self.end_turn_button['center_y'],
+            arcade.color.WHITE,
+            12,
+            anchor_x="center",
+            anchor_y="center",
+        )
+        arcade.draw_xywh_rectangle_filled(
+            self.draw_card_button['center_x'] - self.draw_card_button['width'] / 2,
+            self.draw_card_button['center_y'] - self.draw_card_button['height'] / 2,
+            self.draw_card_button['width'],
+            self.draw_card_button['height'],
+            arcade.color.GRAY,
+        )
+        arcade.draw_text(
+            "Draw Card",
+            self.draw_card_button['center_x'],
+            self.draw_card_button['center_y'],
+            arcade.color.WHITE,
+            12,
+            anchor_x="center",
+            anchor_y="center",
+        )
 
         # Draw spell hand
         y_pos = SCREEN_HEIGHT - 100
@@ -160,10 +184,22 @@ class GridsGame(arcade.Window):
             }
             color = arcade.color.LIGHT_GREEN if idx == self.selected_card_index else arcade.color.DARK_SLATE_GRAY
 
-            arcade.draw_lbwh_rectangle_filled(rect['center_x'], rect['center_y'], rect['width'], rect['height'], color)
+            arcade.draw_xywh_rectangle_filled(
+                rect['center_x'] - rect['width'] / 2,
+                rect['center_y'] - rect['height'] / 2,
+                rect['width'],
+                rect['height'],
+                color,
+            )
             text_x = rect['center_x'] - rect['width'] / 2 + 5
             text_y = rect['center_y'] - 8
-            arcade.draw_text(f"{idx}: {card.name} (Cost: {card.cost})", text_x, text_y, arcade.color.WHITE, 12)
+            arcade.draw_text(
+                f"{idx}: {card.name} (Cost: {card.cost})",
+                text_x,
+                text_y,
+                arcade.color.WHITE,
+                12,
+            )
             self.card_rects.append(rect)
 
     def on_mouse_press(self, x, y, button, modifiers):


### PR DESCRIPTION
## Summary
- use `draw_xywh_rectangle_filled` for UI panel and cards
- compute rectangle positions from centre coordinates
- center button text using `anchor_x`/`anchor_y`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843320089f8832580f372561bf6682a