### PR TITLE
Fix drawing for Arcade 3

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -15,4 +15,17 @@ class GameEntity:
         self.sprite.center_y = row * CELL_SIZE + CELL_SIZE / 2
 
     def draw(self):
-        self.sprite.draw()
+        """Draw the entity using basic shapes.
+
+        Arcade 3.x removed the ``Sprite.draw`` method that earlier versions
+        relied on. Instead of drawing the sprite directly we replicate the
+        behaviour using :func:`arcade.draw_circle_filled` which works for the
+        ``SpriteCircle`` objects used throughout the project.
+        """
+        radius = self.sprite.width / 2
+        arcade.draw_circle_filled(
+            self.sprite.center_x,
+            self.sprite.center_y,
+            radius,
+            self.sprite.color,
+        )

--- a/units.py
+++ b/units.py
@@ -31,9 +31,21 @@ class Unit(GameEntity):
         self.move_queue = []
 
     def draw(self):
+        """Render the unit.
+
+        ``arcade.Sprite`` no longer exposes a ``draw`` method in recent
+        versions of the library. To keep the original visuals we draw a filled
+        circle matching the sprite's appearance.
+        """
         self.sprite.center_x = self.pixel_x
         self.sprite.center_y = self.pixel_y
-        self.sprite.draw()
+        radius = self.sprite.width / 2
+        arcade.draw_circle_filled(
+            self.sprite.center_x,
+            self.sprite.center_y,
+            radius,
+            self.sprite.color,
+        )
 
     def start_move(self, path):
         self.move_queue = path


### PR DESCRIPTION
## Summary
- update `GameEntity.draw` and `Unit.draw` to work with Arcade 3 where `Sprite.draw` was removed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684346f933688325a37e23e4e52ffe13