### PR TITLE
Add Teleport spell

### DIFF
--- a/cards.py
+++ b/cards.py
@@ -1,4 +1,5 @@
 from units import Unit
+from constants import CELL_SIZE
 
 class Card:
     def __init__(self, name, cost, description):
@@ -62,3 +63,36 @@ class ActionBlock(Card):
             else:
                 game.player2BlockedTurnsTimer = 3
                 print("player 2 actions are blocked for 3 turns.")
+
+
+class Teleport(Card):
+    def __init__(self):
+        super().__init__(
+            "Teleport",
+            cost=4,
+            description="Teleport a friendly unit to any square on the board.",
+        )
+
+    def play(self, game, target):
+        unit = game.selected_unit
+        if not unit or unit.owner != game.current_player:
+            print("No friendly unit selected for teleport.")
+            return
+
+        if isinstance(target, Unit):
+            dest_row, dest_col = target.row, target.col
+        else:
+            dest_row, dest_col = target
+
+        if any(u.row == dest_row and u.col == dest_col for u in game.units):
+            print("Destination occupied!")
+            return
+
+        unit.row = dest_row
+        unit.col = dest_col
+        unit.pixel_x = dest_col * CELL_SIZE + CELL_SIZE / 2
+        unit.pixel_y = dest_row * CELL_SIZE + CELL_SIZE / 2
+        unit.target_pixel_x = unit.pixel_x
+        unit.target_pixel_y = unit.pixel_y
+        unit.move_queue = []
+        print(f"Teleported {unit.unit_type} to ({dest_row}, {dest_col}).")

--- a/game.py
+++ b/game.py
@@ -5,7 +5,14 @@ import random
 from constants import (SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE, ROWS, COLUMNS,
                        CELL_SIZE, GRID_WIDTH, GRID_HEIGHT, UI_PANEL_WIDTH)
 from units import (Unit, Warrior, Archer, Healer, Trebuchet, Viking)
-from cards import (Fireball, Freeze, StrengthUp, MeteoriteStrike, ActionBlock)
+from cards import (
+    Fireball,
+    Freeze,
+    StrengthUp,
+    MeteoriteStrike,
+    ActionBlock,
+    Teleport,
+)
 
 class GridsGame(arcade.Window):
     def __init__(self):
@@ -22,7 +29,14 @@ class GridsGame(arcade.Window):
         self.player2BlockedTurnsTimer = 0
 
         self.unit_deck = []
-        self.spell_deck = [Fireball(), Freeze(), StrengthUp(), MeteoriteStrike(), ActionBlock()]
+        self.spell_deck = [
+            Fireball(),
+            Freeze(),
+            StrengthUp(),
+            MeteoriteStrike(),
+            ActionBlock(),
+            Teleport(),
+        ]
         self.unit_hand = []
         self.spell_hand = []
 

--- a/grids.py
+++ b/grids.py
@@ -3,14 +3,28 @@ from constants import (SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE, ROWS, COLUMNS,
 from game import GridsGame, main
 from entities import GameEntity
 from units import (Unit, Warrior, Archer, Healer, Trebuchet, Viking)
-from cards import (Card, Fireball, Freeze, StrengthUp, MeteoriteStrike, ActionBlock)
+from cards import (
+    Card,
+    Fireball,
+    Freeze,
+    StrengthUp,
+    MeteoriteStrike,
+    ActionBlock,
+    Teleport,
+)
 
 __all__ = [
     'SCREEN_WIDTH', 'SCREEN_HEIGHT', 'SCREEN_TITLE',
     'ROWS', 'COLUMNS', 'CELL_SIZE', 'GRID_WIDTH', 'GRID_HEIGHT', 'UI_PANEL_WIDTH',
     'GridsGame', 'main', 'GameEntity',
     'Unit', 'Warrior', 'Archer', 'Healer', 'Trebuchet', 'Viking',
-    'Card', 'Fireball', 'Freeze', 'StrengthUp', 'MeteoriteStrike', 'ActionBlock'
+    'Card',
+    'Fireball',
+    'Freeze',
+    'StrengthUp',
+    'MeteoriteStrike',
+    'ActionBlock',
+    'Teleport'
 ]
 
 if __name__ == '__main__':

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -3,11 +3,23 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import pytest
 from unittest.mock import patch
 import arcade
-from grids import GridsGame, CELL_SIZE, GRID_WIDTH, GRID_HEIGHT, ROWS, COLUMNS
+from grids import (
+    GridsGame,
+    CELL_SIZE,
+    GRID_WIDTH,
+    GRID_HEIGHT,
+    ROWS,
+    COLUMNS,
+    Teleport,
+)
 
 @pytest.fixture
 def game():
-    with patch('arcade.Window.__init__', return_value=None):
+    with patch('arcade.Window.__init__', return_value=None), \
+         patch('arcade.Sprite') as MockSprite:
+        MockSprite.return_value.center_x = 0
+        MockSprite.return_value.center_y = 0
+        MockSprite.return_value.color = None
         g = GridsGame()
     return g
 
@@ -25,3 +37,16 @@ def test_get_clicked_cell_outside(game):
 def test_manhattan_distance(game):
     assert game.manhattan_distance((0, 0), (1, 1)) == 2
     assert game.manhattan_distance((0, 0), (ROWS - 1, COLUMNS - 1)) == (ROWS - 1) + (COLUMNS - 1)
+
+
+def test_teleport_spell(game):
+    teleport = Teleport()
+    game.spell_hand.append(teleport)
+    unit = next(u for u in game.units if u.owner == game.current_player)
+    game.selected_unit = unit
+    dest = (0, COLUMNS - 2)
+    assert all(not (u.row == dest[0] and u.col == dest[1]) for u in game.units)
+    starting_ap = game.current_action_points
+    game.play_card(teleport, dest)
+    assert unit.row == dest[0] and unit.col == dest[1]
+    assert game.current_action_points == starting_ap - teleport.cost


### PR DESCRIPTION
## Summary
- create a Teleport card to move a selected unit anywhere
- include Teleport in game decks and exports
- adjust tests to handle sprite mocking and verify teleport spell

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845935230508325892dfe811504e966