### PR TITLE
Fix unit removal when killed

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -107,6 +107,11 @@ class GameState:
         if target.health <= 0:
             return
         target.health -= attacker.attack
+        if target.health <= 0:
+            # remove defeated unit immediately so its cell becomes free
+            self.units = [u for u in self.units if u is not target]
+            return True
+
         dr = target.row - attacker.row
         dc = target.col - attacker.col
         knock_row = target.row + (1 if dr > 0 else -1 if dr < 0 else 0)
@@ -118,10 +123,7 @@ class GameState:
                     target.col = knock_col
                     # keep pixel values in sync with logical position so
                     # pathfinding and rendering remain consistent after
-                    # knockback. Missing this update previously meant units
-                    # could visually stay in place while their logical
-                    # location changed, allowing other units to occupy the
-                    # same square.
+                    # knockback.
                     target.pixel_x = knock_col * CELL_SIZE + CELL_SIZE / 2
                     target.pixel_y = knock_row * CELL_SIZE + CELL_SIZE / 2
                     target.target_pixel_x = target.pixel_x

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -12,6 +12,8 @@ from grids import (
     COLUMNS,
     Teleport,
 )
+from game_state import GameState
+from units import Warrior
 
 @pytest.fixture
 def game():
@@ -83,3 +85,15 @@ def test_move_unit_single_step(game):
     assert dest is not None, "No available unit with a free neighbouring cell"
 
     assert game.move_unit(unit, *dest)
+
+
+def test_unit_removed_on_death():
+    """Units reduced to zero health should be removed immediately."""
+    state = GameState()
+    state.units = []
+    attacker = Warrior(0, 0, owner=1)
+    target = Warrior(0, 1, owner=2)
+    target.health = 10
+    state.units = [attacker, target]
+    state.attack_unit(attacker, target)
+    assert target not in state.units


### PR DESCRIPTION
## Summary
- remove defeated units immediately in `GameState.attack_unit`
- ensure game handles dead units instantly via new regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a3c369648325b2850a5761b7e28a