### PR TITLE
Add unit deployment mechanic

### DIFF
--- a/grids_env.py
+++ b/grids_env.py
@@ -16,7 +16,8 @@ class GridsEnv(gym.Env):
         self.state = GameState()
         self.action_space = spaces.Tuple(
             (
-                spaces.Discrete(20),  # unit index
+                spaces.Discrete(2),  # 0=move unit, 1=deploy unit
+                spaces.Discrete(20),  # unit or hand index
                 spaces.Discrete(ROWS),
                 spaces.Discrete(COLUMNS),
             )
@@ -41,12 +42,26 @@ class GridsEnv(gym.Env):
         return self._get_obs(), {}
 
     def step(self, action):
-        unit_idx, row, col = action
-        if unit_idx >= len(self.state.units):
+        action_type, idx, row, col = action
+
+        if action_type == 0:  # move existing unit
+            if idx >= len(self.state.units):
+                return self._get_obs(), -1.0, True, False, {}
+            unit = self.state.units[idx]
+            ok = self.state.move_unit(unit, row, col, animate=self.animate)
+            reward = 1.0 if ok else -1.0
+        elif action_type == 1:  # deploy unit from hand
+            if idx >= len(self.state.unit_hand):
+                return self._get_obs(), -1.0, True, False, {}
+            unit_cls = self.state.unit_hand[idx]
+            if (row, col) not in self.state.get_valid_deploy_squares():
+                return self._get_obs(), -1.0, True, False, {}
+            unit = self.state.place_unit(unit_cls, row, col)
+            reward = 1.0 if unit else -1.0
+        else:
+            # unsupported action type
             return self._get_obs(), -1.0, True, False, {}
-        unit = self.state.units[unit_idx]
-        ok = self.state.move_unit(unit, row, col, animate=self.animate)
-        reward = 1.0 if ok else -1.0
+
         terminated = False
         truncated = False
         return self._get_obs(), reward, terminated, truncated, {}

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,15 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import gym
+from grids_env import GridsEnv
+
+
+def test_deploy_action():
+    env = GridsEnv()
+    assert env.state.unit_hand
+    square = env.state.get_valid_deploy_squares()[0]
+    action = (1, 0, square[0], square[1])
+    obs, reward, term, trunc, _ = env.step(action)
+    assert reward == 1.0
+    assert any(u.row == square[0] and u.col == square[1] for u in env.state.units)
+    assert not term and not trunc

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -97,3 +97,20 @@ def test_unit_removed_on_death():
     state.units = [attacker, target]
     state.attack_unit(attacker, target)
     assert target not in state.units
+
+
+def test_get_valid_deploy_squares(game):
+    squares = game.get_valid_deploy_squares()
+    for r, c in squares:
+        assert c == 0
+        assert all(not (u.row == r and u.col == c) for u in game.units)
+
+
+def test_place_unit(game):
+    squares = game.get_valid_deploy_squares()
+    unit_cls = game.unit_hand[0]
+    ap_before = game.current_action_points
+    game.place_unit(unit_cls, *squares[0])
+    assert any(u.row == squares[0][0] and u.col == squares[0][1] for u in game.units)
+    assert len(game.unit_hand) == 2
+    assert game.current_action_points == ap_before - 1

--- a/units.py
+++ b/units.py
@@ -13,7 +13,7 @@ class Unit(GameEntity):
         "Trebuchet": "sprites/units/trebuchet.png",
         "Viking": "sprites/units/viking.png",
     }
-    def __init__(self, row, col, unit_type, owner, health, attack, move_range, attack_range, cost):
+    def __init__(self, row, col, unit_type, owner, health, attack, move_range, attack_range, cost, deploy_cost=1):
         color = arcade.color.BLUE if owner == 1 else arcade.color.RED
         sprite_path = self.SPRITE_PATHS.get(unit_type, "sprites/units/commander.png")
         # Original unit artwork is extremely large (1024x1536 pixels). Scaling
@@ -30,6 +30,7 @@ class Unit(GameEntity):
         self.move_range = move_range
         self.attack_range = attack_range
         self.cost = cost
+        self.deploy_cost = deploy_cost
         # Additional status flags
         self.frozen_turns = 0
         self.action_blocked = False


### PR DESCRIPTION
## Summary
- add `deploy_cost` to `Unit`
- allow `GameState` to calculate valid deployment squares and place units
- enable selecting unit cards to highlight deployment options
- deploy units on the left/right columns with action point cost
- support AI deployment through updated `GridsEnv`
- add tests for environment deploy action

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a6d649ec8325b249d969cbdfe891