### PR TITLE
Fix unit list references when units die

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -141,7 +141,7 @@ class GameState:
         target.health -= attacker.attack
         if target.health <= 0:
             # remove defeated unit immediately so its cell becomes free
-            self.units = [u for u in self.units if u is not target]
+            self.units[:] = [u for u in self.units if u is not target]
             return True
 
         dr = target.row - attacker.row
@@ -241,4 +241,5 @@ class GameState:
         for unit in self.units:
             if unit.frozen_turns > 0:
                 unit.frozen_turns -= 1
-        self.units = [u for u in self.units if u.health > 0]
+        # modify the list in-place so external references remain valid
+        self.units[:] = [u for u in self.units if u.health > 0]


### PR DESCRIPTION
## Summary
- keep `state.units` list object stable when units are removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b0d6a1a883258622f0b2e0fa55e7