### PR TITLE
Add spell status effects

### DIFF
--- a/game.py
+++ b/game.py
@@ -141,6 +141,8 @@ class GridsGame(arcade.Window):
                     color = arcade.color.LIGHT_BLUE
                 if (row, col) in self.deploy_squares:
                     color = arcade.color.DARK_SPRING_GREEN
+                if (row, col) in self.state.fires:
+                    color = arcade.color.ORANGE
                 cell_rect = arcade.Rect(
                     left=x - CELL_SIZE/2,
                     right=x + CELL_SIZE/2,
@@ -152,7 +154,11 @@ class GridsGame(arcade.Window):
                     height=CELL_SIZE
                 )
                 arcade.draw_rect_outline(cell_rect, color, border_width=2)
-                if (row, col) in self.move_squares or (row, col) in self.deploy_squares:
+                if (
+                    (row, col) in self.move_squares
+                    or (row, col) in self.deploy_squares
+                    or (row, col) in self.state.fires
+                ):
                     arcade.draw_rect_filled(cell_rect, color)
         for target in self.attack_targets:
             x = target.col * CELL_SIZE + CELL_SIZE / 2
@@ -374,7 +380,6 @@ class GridsGame(arcade.Window):
     def on_update(self, delta_time):
         for unit in self.state.units:
             unit.update_animation(delta_time)
-        self.state.update()
         self.player1BlockedTurnsTimer = self.state.player1BlockedTurnsTimer
         self.player2BlockedTurnsTimer = self.state.player2BlockedTurnsTimer
         self.current_action_points = self.state.current_action_points

--- a/units.py
+++ b/units.py
@@ -33,6 +33,7 @@ class Unit(GameEntity):
         self.deploy_cost = deploy_cost
         # Additional status flags
         self.frozen_turns = 0
+        self.burn_turns = 0
         self.action_blocked = False
 
         # Animation attributes
@@ -50,6 +51,22 @@ class Unit(GameEntity):
         self.sprite.center_x = self.pixel_x
         self.sprite.center_y = self.pixel_y
         arcade.draw_sprite(self.sprite)
+        if self.frozen_turns > 0:
+            arcade.draw_text(
+                "F",
+                self.pixel_x - CELL_SIZE / 4,
+                self.pixel_y + CELL_SIZE / 4,
+                arcade.color.CYAN,
+                12,
+            )
+        if self.burn_turns > 0:
+            arcade.draw_text(
+                "B",
+                self.pixel_x + CELL_SIZE / 4 - 8,
+                self.pixel_y + CELL_SIZE / 4,
+                arcade.color.RED,
+                12,
+            )
 
     def start_move(self, path):
         """Begin moving along the provided path."""


### PR DESCRIPTION
## Summary
- implement lingering fire and burning damage for Fireball
- implement meteorite knockback logic
- allow ActionBlock to reduce actions for two turns
- support frozen and burning indicators on units
- store burning tiles and render them
- process status effects on turn end

## Testing
- `pip install gym==0.26.2 arcade==2.6.17`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b2666360832580f5c566f34e2325