### PR TITLE
Add unit detail info on selection

### DIFF
--- a/game.py
+++ b/game.py
@@ -333,9 +333,7 @@ class GridsGame(arcade.Window):
                         self.selected_unit = unit
                         self.move_squares = self.get_valid_move_squares(unit)
                         self.attack_targets = self.get_attackable_units(unit)
-                        print(
-                            f"Selected unit: {unit.unit_type} (Owner: {unit.owner})"
-                        )
+                        print("Selected unit:", unit.describe())
                         return
                     elif (
                         self.selected_unit

--- a/units.py
+++ b/units.py
@@ -46,6 +46,14 @@ class Unit(GameEntity):
         self.animation_timer = 0.0
         self.move_queue = []
 
+    def describe(self):
+        """Return a human-readable summary of the unit's key stats."""
+        return (
+            f"{self.unit_type} (Owner: {self.owner}) - "
+            f"HP: {self.health}, ATK: {self.attack}, "
+            f"Move: {self.move_range}, Range: {self.attack_range}"
+        )
+
     def draw(self):
         """Render the unit sprite."""
         self.sprite.center_x = self.pixel_x


### PR DESCRIPTION
## Summary
- add a new `describe` helper in `Unit`
- print unit stats when clicking a unit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b6b3e8308325b2302fab3a0d9f3a