### PR TITLE
Implement basic self-play framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ pytest
 ```
 
 This will execute all unit tests.
+
+## Self-Play Example
+
+The repository includes a simple `RandomAgent` and a `self_play.py` script
+demonstrating how two agents can interact with the `GridsEnv` environment.
+Run the script to watch a few turns of automated play:
+
+```bash
+python self_play.py
+```
+
+This uses purely random actions, but provides a starting point for more
+advanced reinforcement learning experiments.

--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,8 @@
+import random
+from grids_env import GridsEnv
+
+class RandomAgent:
+    """Agent that selects a random valid action."""
+    def act(self, env: GridsEnv):
+        actions = env.valid_actions()
+        return random.choice(actions) if actions else (2,0,0,0)

--- a/grids_env.py
+++ b/grids_env.py
@@ -1,5 +1,6 @@
 import gym
 from gym import spaces
+import numpy as np
 
 from game_state import GameState
 from constants import ROWS, COLUMNS
@@ -16,7 +17,7 @@ class GridsEnv(gym.Env):
         self.state = GameState()
         self.action_space = spaces.Tuple(
             (
-                spaces.Discrete(2),  # 0=move unit, 1=deploy unit
+                spaces.Discrete(3),  # 0=move, 1=deploy, 2=end turn
                 spaces.Discrete(20),  # unit or hand index
                 spaces.Discrete(ROWS),
                 spaces.Discrete(COLUMNS),
@@ -26,14 +27,26 @@ class GridsEnv(gym.Env):
             {
                 "current_player": spaces.Discrete(3),
                 "action_points": spaces.Discrete(100),
+                "board_owner": spaces.Box(0, 2, (ROWS, COLUMNS), dtype=np.int8),
+                "board_health": spaces.Box(0, 500, (ROWS, COLUMNS), dtype=np.int16),
+                "opponent_hand": spaces.Discrete(11),
             }
         )
 
     # ------------------------------------------------------------------
     def _get_obs(self):
+        board_owner = np.zeros((ROWS, COLUMNS), dtype=np.int8)
+        board_health = np.zeros((ROWS, COLUMNS), dtype=np.int16)
+        for unit in self.state.units:
+            board_owner[unit.row, unit.col] = unit.owner
+            board_health[unit.row, unit.col] = unit.health
+        opponent = 2 if self.state.current_player == 1 else 1
         return {
             "current_player": self.state.current_player,
             "action_points": self.state.current_action_points,
+            "board_owner": board_owner,
+            "board_health": board_health,
+            "opponent_hand": len(self.state.hands[opponent]),
         }
 
     def reset(self, *, seed=None, options=None):
@@ -58,13 +71,33 @@ class GridsEnv(gym.Env):
                 return self._get_obs(), -1.0, True, False, {}
             unit = self.state.place_unit(unit_cls, row, col)
             reward = 1.0 if unit else -1.0
+        elif action_type == 2:  # end turn
+            self.state.end_turn()
+            reward = 0.0
         else:
             # unsupported action type
             return self._get_obs(), -1.0, True, False, {}
 
+        if self.state.current_action_points <= 0:
+            self.state.end_turn()
+
         terminated = False
         truncated = False
         return self._get_obs(), reward, terminated, truncated, {}
+
+    def valid_actions(self):
+        actions = []
+        player = self.state.current_player
+        for idx, unit in enumerate(self.state.units):
+            if unit.owner != player:
+                continue
+            for r, c in self.state.get_valid_move_squares(unit):
+                actions.append((0, idx, r, c))
+        for idx, unit_cls in enumerate(self.state.unit_hands[player]):
+            for r, c in self.state.get_valid_deploy_squares(player):
+                actions.append((1, idx, r, c))
+        actions.append((2, 0, 0, 0))
+        return actions
 
     def render(self):
         if self.render_mode == "human":

--- a/self_play.py
+++ b/self_play.py
@@ -1,0 +1,20 @@
+from grids_env import GridsEnv
+from agents import RandomAgent
+
+
+def self_play(num_episodes=5, max_steps=50):
+    env = GridsEnv()
+    agents = {1: RandomAgent(), 2: RandomAgent()}
+    for ep in range(num_episodes):
+        obs, _ = env.reset()
+        for step in range(max_steps):
+            player = env.state.current_player
+            action = agents[player].act(env)
+            obs, reward, term, trunc, _ = env.step(action)
+            if term or trunc:
+                break
+        print(f"Episode {ep+1} finished")
+
+
+if __name__ == "__main__":
+    self_play()


### PR DESCRIPTION
## Summary
- expand environment observations to include board state
- support end-turn actions and expose valid actions
- add simple `RandomAgent` and `self_play.py` example
- document how to run self-play in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b87068648325ab0b61044574cb8b