### PR TITLE
Add healer healing ability

### DIFF
--- a/game.py
+++ b/game.py
@@ -329,13 +329,7 @@ class GridsGame(arcade.Window):
 
             for unit in self.units:
                 if unit.row == row and unit.col == col:
-                    if unit.owner == self.current_player:
-                        self.selected_unit = unit
-                        self.move_squares = self.get_valid_move_squares(unit)
-                        self.attack_targets = self.get_attackable_units(unit)
-                        print("Selected unit:", unit.describe())
-                        return
-                    elif (
+                    if (
                         self.selected_unit
                         and unit in self.attack_targets
                         and self.selected_unit.owner == self.current_player
@@ -344,6 +338,12 @@ class GridsGame(arcade.Window):
                         self.attack_targets = []
                         self.move_squares = []
                         self.selected_unit = None
+                        return
+                    if unit.owner == self.current_player:
+                        self.selected_unit = unit
+                        self.move_squares = self.get_valid_move_squares(unit)
+                        self.attack_targets = self.get_attackable_units(unit)
+                        print("Selected unit:", unit.describe())
                         return
             if self.selected_unit and (row, col) in self.move_squares:
                 self.move_unit(self.selected_unit, row, col)

--- a/game_state.py
+++ b/game_state.py
@@ -141,6 +141,14 @@ class GameState:
     def attack_unit(self, attacker, target):
         if attacker.frozen_turns > 0:
             return False
+        if attacker.unit_type == "Healer":
+            if attacker.owner == target.owner:
+                # Heal friendly target up to its maximum health
+                target.health = min(target.health + attacker.attack, target.max_health)
+                return True
+            else:
+                # Healers cannot damage enemies
+                return False
         if target.health <= 0:
             return
         target.health -= attacker.attack
@@ -212,10 +220,16 @@ class GameState:
     def get_attackable_units(self, unit):
         targets = []
         for other in self.units:
-            if other.owner != unit.owner:
-                dist = self.manhattan_distance((unit.row, unit.col), (other.row, other.col))
-                if dist <= unit.attack_range:
-                    targets.append(other)
+            if unit.unit_type == "Healer":
+                if other.owner == unit.owner and other is not unit:
+                    dist = self.manhattan_distance((unit.row, unit.col), (other.row, other.col))
+                    if dist <= unit.attack_range:
+                        targets.append(other)
+            else:
+                if other.owner != unit.owner:
+                    dist = self.manhattan_distance((unit.row, unit.col), (other.row, other.col))
+                    if dist <= unit.attack_range:
+                        targets.append(other)
         return targets
 
     def a_star_pathfinding(self, start, goal):

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -13,7 +13,7 @@ from grids import (
     Teleport,
 )
 from game_state import GameState
-from units import Warrior
+from units import Warrior, Healer
 
 @pytest.fixture
 def game():
@@ -114,3 +114,19 @@ def test_place_unit(game):
     assert any(u.row == squares[0][0] and u.col == squares[0][1] for u in game.units)
     assert len(game.unit_hand) == 2
     assert game.current_action_points == ap_before - 1
+
+
+def test_healer_heals_friendly_and_not_enemy():
+    state = GameState()
+    state.units = []
+    healer = Healer(0, 0, owner=1)
+    ally = Warrior(0, 1, owner=1)
+    enemy = Warrior(0, 2, owner=2)
+    ally.health = 40
+    state.units = [healer, ally, enemy]
+    state.attack_unit(healer, ally)
+    assert ally.health > 40
+    assert ally.health <= ally.max_health
+    prev = enemy.health
+    state.attack_unit(healer, enemy)
+    assert enemy.health == prev

--- a/units.py
+++ b/units.py
@@ -26,6 +26,8 @@ class Unit(GameEntity):
         self.unit_type = unit_type
         self.owner = owner  # e.g., player 1 or 2
         self.health = health
+        # Track the maximum health so healing cannot exceed the original value
+        self.max_health = health
         self.attack = attack
         self.move_range = move_range
         self.attack_range = attack_range


### PR DESCRIPTION
## Summary
- support maximum health for all units
- allow healer to heal friendly units and prevent damaging enemies
- show friendly units as targets for healer
- prioritize healing in click handling
- test healer healing behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bb4a22e083258e72ebbcd077e683