### PR TITLE
Add commander death win condition

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -32,6 +32,10 @@ class GameState:
         self.player2BlockedTurnsTimer = 0
         self.fires = {}
 
+        # None while the game is ongoing, otherwise set to the winning player's
+        # number (1 or 2).
+        self.winner = None
+
         # stateful selections used by some cards
         self.selected_unit = None
 
@@ -57,6 +61,29 @@ class GameState:
 
         # convenience references for the current player
         self.refresh_player_hands()
+
+    # ------------------------------------------------------------------
+    def check_winner(self):
+        """Update the winner attribute based on remaining commanders."""
+        p1_alive = any(
+            u.unit_type == "Commander" and u.owner == 1 for u in self.units
+        )
+        p2_alive = any(
+            u.unit_type == "Commander" and u.owner == 2 for u in self.units
+        )
+        if not p1_alive and not p2_alive:
+            self.winner = None
+        elif not p1_alive:
+            self.winner = 2
+        elif not p2_alive:
+            self.winner = 1
+        else:
+            self.winner = None
+
+    def remove_dead_units(self):
+        """Remove units with no health and check for a winner."""
+        self.units[:] = [u for u in self.units if u.health > 0]
+        self.check_winner()
 
     def refresh_player_hands(self):
         """Update convenience references for the current player."""
@@ -145,8 +172,9 @@ class GameState:
             return
         target.health -= attacker.attack
         if target.health <= 0:
-            # remove defeated unit immediately so its cell becomes free
-            self.units[:] = [u for u in self.units if u is not target]
+            # remove defeated unit immediately so its cell becomes free and
+            # check if the game has been won.
+            self.remove_dead_units()
             return True
 
         dr = target.row - attacker.row
@@ -194,6 +222,8 @@ class GameState:
         if card in self.hands[player]:
             self.hands[player].remove(card)
         self.current_action_points -= card.cost
+        # cards may defeat units (including commanders)
+        self.remove_dead_units()
         self.refresh_player_hands()
         return True
 
@@ -269,4 +299,4 @@ class GameState:
         for pos in expired:
             del self.fires[pos]
         # modify the list in-place so external references remain valid
-        self.units[:] = [u for u in self.units if u.health > 0]
+        self.remove_dead_units()

--- a/grids_env.py
+++ b/grids_env.py
@@ -81,7 +81,7 @@ class GridsEnv(gym.Env):
         if self.state.current_action_points <= 0:
             self.state.end_turn()
 
-        terminated = False
+        terminated = self.state.winner is not None
         truncated = False
         return self._get_obs(), reward, terminated, truncated, {}
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import gym
 from grids_env import GridsEnv
+from game_state import GameState
 
 
 def test_deploy_action():
@@ -13,3 +14,23 @@ def test_deploy_action():
     assert reward == 1.0
     assert any(u.row == square[0] and u.col == square[1] for u in env.state.units)
     assert not term and not trunc
+
+
+def test_game_winner_set_on_commander_death():
+    state = GameState()
+    attacker = next(u for u in state.units if u.owner == 1 and u.unit_type != "Commander")
+    commander = next(u for u in state.units if u.owner == 2 and u.unit_type == "Commander")
+    commander.health = 1
+    state.attack_unit(attacker, commander)
+    assert state.winner == 1
+
+
+def test_env_terminates_when_commander_dies():
+    env = GridsEnv()
+    attacker = next(u for u in env.state.units if u.owner == 1 and u.unit_type != "Commander")
+    commander = next(u for u in env.state.units if u.owner == 2 and u.unit_type == "Commander")
+    commander.health = 1
+    env.state.attack_unit(attacker, commander)
+    obs, reward, term, trunc, _ = env.step((2, 0, 0, 0))
+    assert term
+    assert env.state.winner == 1


### PR DESCRIPTION
## Summary
- add tracking for which player wins in `GameState`
- remove defeated units with new helper method and detect winner
- end an environment episode when a commander is killed
- test that killing a commander sets the winner and ends the episode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bbaa3cfc8325b0c65ff14bc7ea7e