### PR TITLE
Ensure symmetric starting decks

### DIFF
--- a/game.py
+++ b/game.py
@@ -24,8 +24,6 @@ class GridsGame(arcade.Window):
         self.state = GameState()
 
         # convenience references used by UI code
-        self.unit_deck = self.state.unit_deck
-        self.spell_deck = self.state.spell_deck
         self.hand = self.state.hand
         self.unit_hand = self.state.unit_hand
         self.spell_hand = self.state.spell_hand
@@ -282,10 +280,12 @@ class GridsGame(arcade.Window):
                 self.end_turn()
                 return
             if self.point_in_rect(x, y, self.draw_card_button):
-                self.draw_cards(self.spell_deck, self.current_player, num=1, ap_cost=1)
+                deck = self.state.spell_decks[self.current_player]
+                self.draw_cards(deck, self.current_player, num=1, ap_cost=1)
                 return
             if self.point_in_rect(x, y, self.draw_unit_button):
-                self.draw_cards(self.unit_deck, self.current_player, num=1, ap_cost=1)
+                deck = self.state.unit_decks[self.current_player]
+                self.draw_cards(deck, self.current_player, num=1, ap_cost=1)
                 return
             for idx, rect in enumerate(self.card_rects):
                 if self.point_in_rect(x, y, rect):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,6 +3,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import gym
 from grids_env import GridsEnv
 from game_state import GameState
+from units import Warrior
 
 
 def test_deploy_action():
@@ -18,8 +19,9 @@ def test_deploy_action():
 
 def test_game_winner_set_on_commander_death():
     state = GameState()
-    attacker = next(u for u in state.units if u.owner == 1 and u.unit_type != "Commander")
     commander = next(u for u in state.units if u.owner == 2 and u.unit_type == "Commander")
+    attacker = Warrior(commander.row, commander.col - 1, owner=1)
+    state.units.append(attacker)
     commander.health = 1
     state.attack_unit(attacker, commander)
     assert state.winner == 1
@@ -27,8 +29,9 @@ def test_game_winner_set_on_commander_death():
 
 def test_env_terminates_when_commander_dies():
     env = GridsEnv()
-    attacker = next(u for u in env.state.units if u.owner == 1 and u.unit_type != "Commander")
     commander = next(u for u in env.state.units if u.owner == 2 and u.unit_type == "Commander")
+    attacker = Warrior(commander.row, commander.col - 1, owner=1)
+    env.state.units.append(attacker)
     commander.health = 1
     env.state.attack_unit(attacker, commander)
     obs, reward, term, trunc, _ = env.step((2, 0, 0, 0))


### PR DESCRIPTION
## Summary
- add separate shuffled decks for each player with two of every card
- only place commanders at start and draw three cards each for both players
- expose decks via properties and adjust UI
- update tests for new starting conditions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c07519c883259dd6cfce75ff2619