### PR TITLE
Add visual AI mode and save trained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ advanced reinforcement learning experiments.
 
 A simple Deep Q-Network agent and training script are included for
 experimenting with learning in `GridsEnv`. Install PyTorch and run
-`train_dqn.py` to train two agents in self‑play:
+`train_dqn.py` to train two agents in self‑play. The weights of the first
+agent are written to `dqn_model.pth` at the end of training:
 
 ```bash
 pip install torch
@@ -54,3 +55,16 @@ python train_dqn.py
 
 This implementation is intentionally lightweight and is aimed at CPU
 training on a laptop.
+
+## Watching AI vs AI With Graphics
+
+To simply watch two agents play a match with the graphical interface enabled,
+run the `ai_vs_ai.py` script:
+
+```bash
+python ai_vs_ai.py
+```
+
+By default random agents are used. If you have a saved model from training,
+replace them in the script with `DQNAgent` instances and call `load` with the
+path to the weight file.

--- a/ai_vs_ai.py
+++ b/ai_vs_ai.py
@@ -1,0 +1,53 @@
+import time
+import arcade
+from game import GridsGame
+from grids_env import GridsEnv
+from agents import RandomAgent
+from dqn_agent import DQNAgent
+
+class AIVsAI(GridsGame):
+    """Visualize two AI agents playing against each other."""
+    def __init__(self, agent1, agent2, step_delay: float = 0.5):
+        self.env = GridsEnv(animate=True)
+        self.agent1 = agent1
+        self.agent2 = agent2
+        self.step_delay = step_delay
+        super().__init__()
+        # replace the state created by ``GridsGame`` with the environment state
+        self.state = self.env.state
+        self.sync_hands()
+        self.units = self.state.units
+        self.obstacles = self.state.obstacles
+        self.last_step = time.time()
+
+    def on_update(self, delta_time):
+        super().on_update(delta_time)
+        if self.state.winner:
+            return
+        if time.time() - self.last_step < self.step_delay:
+            return
+        obs = self.env._get_obs()
+        player = self.state.current_player
+        agent = self.agent1 if player == 1 else self.agent2
+        if hasattr(agent, "select_action"):
+            action = agent.select_action(obs)
+        else:
+            action = agent.act(self.env)
+        self.env.step(action)
+        self.last_step = time.time()
+        self.units = self.state.units
+        self.sync_hands()
+
+
+def main():
+    # Start with two random agents. Trained models can be loaded by
+    # replacing the agents below with ``DQNAgent`` instances and calling
+    # ``load`` with a saved weight file.
+    agent1 = RandomAgent()
+    agent2 = RandomAgent()
+    window = AIVsAI(agent1, agent2)
+    arcade.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/dqn_agent.py
+++ b/dqn_agent.py
@@ -75,6 +75,16 @@ class DQNAgent:
         self.target_update = target_update
         self.steps_done = 0
 
+    def save(self, path: str) -> None:
+        """Persist the agent's policy network to disk."""
+        torch.save(self.policy_net.state_dict(), path)
+
+    def load(self, path: str) -> None:
+        """Load network weights from ``path`` into the policy and target nets."""
+        state_dict = torch.load(path, map_location="cpu")
+        self.policy_net.load_state_dict(state_dict)
+        self.target_net.load_state_dict(state_dict)
+
     def select_action(self, obs: dict) -> Tuple[int, int, int, int]:
         valid_actions = self.env.valid_actions()
         if random.random() < self.epsilon:

--- a/train_dqn.py
+++ b/train_dqn.py
@@ -26,6 +26,10 @@ def train(num_episodes: int = 50, max_steps: int = 50):
         agent2.decay_epsilon()
         print(f"Episode {ep+1}: reward={total_reward:.2f}")
 
+    # persist the learned policy for later use
+    agent1.save("dqn_model.pth")
+    print("Model saved to dqn_model.pth")
+
 
 if __name__ == "__main__":
     train()


### PR DESCRIPTION
## Summary
- allow DQN agents to save and load weights
- persist training weights at the end of `train_dqn.py`
- implement `ai_vs_ai.py` for watching two agents play with graphics
- document new mode and saved model in README

## Testing
- `pip install gym==0.26.2 arcade==2.6.17`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c947e5f8832595e04d6ef439ee12