### PR TITLE
Add commander damage reward

### DIFF
--- a/grids_env.py
+++ b/grids_env.py
@@ -5,6 +5,13 @@ import numpy as np
 from game_state import GameState
 from constants import ROWS, COLUMNS
 
+# Reward multiplier for damage dealt to the opposing commander.
+DAMAGE_REWARD_SCALE = 0.1
+# Bonus reward when successfully deploying a unit.
+UNIT_DEPLOY_REWARD = 0.2
+# Bonus reward when successfully playing a card.
+ITEM_USE_REWARD = 0.2
+
 class GridsEnv(gym.Env):
     """Gym-compatible environment wrapping :class:`GameState`."""
 
@@ -17,7 +24,7 @@ class GridsEnv(gym.Env):
         self.state = GameState()
         self.action_space = spaces.Tuple(
             (
-                spaces.Discrete(3),  # 0=move, 1=deploy, 2=end turn
+                spaces.Discrete(4),  # 0=move, 1=deploy, 2=play card, 3=end turn
                 spaces.Discrete(20),  # unit or hand index
                 spaces.Discrete(ROWS),
                 spaces.Discrete(COLUMNS),
@@ -49,6 +56,13 @@ class GridsEnv(gym.Env):
             "opponent_hand": len(self.state.hands[opponent]),
         }
 
+    def _commander_health(self, player: int) -> int:
+        """Return the current health of ``player``'s commander."""
+        for unit in self.state.units:
+            if unit.owner == player and unit.unit_type == "Commander":
+                return unit.health
+        return 0
+
     def reset(self, *, seed=None, options=None):
         super().reset(seed=seed)
         self.state = GameState()
@@ -56,6 +70,9 @@ class GridsEnv(gym.Env):
 
     def step(self, action):
         action_type, idx, row, col = action
+
+        opponent = 2 if self.state.current_player == 1 else 1
+        pre_health = self._commander_health(opponent)
 
         if action_type == 0:  # move existing unit
             if idx >= len(self.state.units):
@@ -71,7 +88,17 @@ class GridsEnv(gym.Env):
                 return self._get_obs(), -1.0, True, False, {}
             unit = self.state.place_unit(unit_cls, row, col)
             reward = 1.0 if unit else -1.0
-        elif action_type == 2:  # end turn
+            if unit:
+                reward += UNIT_DEPLOY_REWARD
+        elif action_type == 2:  # play card from hand
+            if idx >= len(self.state.spell_hand):
+                return self._get_obs(), -1.0, True, False, {}
+            card = self.state.spell_hand[idx]
+            ok = self.state.play_card(card, (row, col))
+            reward = 1.0 if ok else -1.0
+            if ok:
+                reward += ITEM_USE_REWARD
+        elif action_type == 3:  # end turn
             self.state.end_turn()
             reward = 0.0
         else:
@@ -80,6 +107,11 @@ class GridsEnv(gym.Env):
 
         if self.state.current_action_points <= 0:
             self.state.end_turn()
+
+        post_health = self._commander_health(opponent)
+        damage = max(0, pre_health - post_health)
+        if damage:
+            reward += damage * DAMAGE_REWARD_SCALE
 
         terminated = self.state.winner is not None
         truncated = False
@@ -96,7 +128,11 @@ class GridsEnv(gym.Env):
         for idx, unit_cls in enumerate(self.state.unit_hands[player]):
             for r, c in self.state.get_valid_deploy_squares(player):
                 actions.append((1, idx, r, c))
-        actions.append((2, 0, 0, 0))
+        for idx, card in enumerate(self.state.spell_hands[player]):
+            for r in range(ROWS):
+                for c in range(COLUMNS):
+                    actions.append((2, idx, r, c))
+        actions.append((3, 0, 0, 0))
         return actions
 
     def render(self):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,7 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import gym
-from grids_env import GridsEnv
+from grids_env import GridsEnv, UNIT_DEPLOY_REWARD
 from game_state import GameState
 from units import Warrior
 
@@ -12,7 +12,7 @@ def test_deploy_action():
     square = env.state.get_valid_deploy_squares()[0]
     action = (1, 0, square[0], square[1])
     obs, reward, term, trunc, _ = env.step(action)
-    assert reward == 1.0
+    assert reward == 1.0 + UNIT_DEPLOY_REWARD
     assert any(u.row == square[0] and u.col == square[1] for u in env.state.units)
     assert not term and not trunc
 
@@ -34,6 +34,14 @@ def test_env_terminates_when_commander_dies():
     env.state.units.append(attacker)
     commander.health = 1
     env.state.attack_unit(attacker, commander)
-    obs, reward, term, trunc, _ = env.step((2, 0, 0, 0))
+    obs, reward, term, trunc, _ = env.step((3, 0, 0, 0))
     assert term
     assert env.state.winner == 1
+
+
+def test_play_card_action():
+    env = GridsEnv()
+    assert env.state.spell_hand
+    action = (2, 0, 0, 0)
+    obs, reward, term, trunc, _ = env.step(action)
+    assert reward >= 1.0


### PR DESCRIPTION
## Summary
- add a damage reward scale constant
- track commander health before and after each action
- boost reward proportional to damage dealt
- reward playing units and spells

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684af2b47ec8832588447ed03d6282ff