### PR TITLE
Fix DQN action size

### DIFF
--- a/dqn_agent.py
+++ b/dqn_agent.py
@@ -10,8 +10,10 @@ import torch.nn.functional as F
 from grids_env import GridsEnv
 from constants import ROWS, COLUMNS
 
-# Size of the discrete action space
-ACTION_SIZE = 3 * 20 * ROWS * COLUMNS
+# Size of the discrete action space. There are four action types
+# (move, deploy, play card, end turn) so the action space must account
+# for all of them.
+ACTION_SIZE = 4 * 20 * ROWS * COLUMNS
 
 
 def action_to_index(action: Tuple[int, int, int, int]) -> int:

--- a/grids_env.py
+++ b/grids_env.py
@@ -132,7 +132,13 @@ class GridsEnv(gym.Env):
             for r in range(ROWS):
                 for c in range(COLUMNS):
                     actions.append((2, idx, r, c))
-        actions.append((3, 0, 0, 0))
+
+        # Only allow ending the turn early if no other actions are available or
+        # the player has exhausted their action points. This encourages the AI
+        # to use all actions each turn.
+        if not actions or self.state.current_action_points <= 0:
+            actions.append((3, 0, 0, 0))
+
         return actions
 
     def render(self):


### PR DESCRIPTION
## Summary
- expand the discrete action space size to cover end-turn actions
- avoid adding the end turn action when the player still has action points or other moves

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684af4d6bb608325a08689df625637b9