### PR TITLE
Fix Teleport card for AI use

### DIFF
--- a/cards.py
+++ b/cards.py
@@ -1,3 +1,4 @@
+import random
 from units import Unit
 from constants import CELL_SIZE, ROWS, COLUMNS
 
@@ -99,8 +100,12 @@ class Teleport(Card):
     def play(self, game, target):
         unit = game.selected_unit
         if not unit or unit.owner != game.current_player:
-            print("No friendly unit selected for teleport.")
-            return
+            # If no unit is selected (e.g. AI usage), pick a random friendly unit
+            friendly = [u for u in game.units if u.owner == game.current_player]
+            if not friendly:
+                print("No friendly unit available for teleport.")
+                return
+            unit = random.choice(friendly)
 
         if isinstance(target, Unit):
             dest_row, dest_col = target.row, target.col

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -152,3 +152,20 @@ def test_healer_heals_friendly_and_not_enemy():
     prev = enemy.health
     state.attack_unit(healer, enemy)
     assert enemy.health == prev
+
+
+def test_teleport_spell_no_selection(game):
+    teleport = Teleport()
+    game.spell_hand.append(teleport)
+    dest = (0, COLUMNS - 2)
+    assert all(
+        not (u.row == dest[0] and u.col == dest[1]) for u in game.units
+    )
+    starting_ap = game.current_action_points
+    # intentionally do not set game.selected_unit
+    game.play_card(teleport, dest)
+    assert any(
+        u.owner == game.current_player and u.row == dest[0] and u.col == dest[1]
+        for u in game.units
+    )
+    assert game.current_action_points == starting_ap - teleport.cost


### PR DESCRIPTION
## Summary
- auto-pick a friendly unit if Teleport is used without a selected unit
- test teleport when no unit is manually selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af691ecf0832584bc9d1757ace417