### PR TITLE
Expose hand info to AI

### DIFF
--- a/dqn_agent.py
+++ b/dqn_agent.py
@@ -34,9 +34,18 @@ def index_to_action(index: int) -> Tuple[int, int, int, int]:
 def obs_to_tensor(obs: dict) -> torch.Tensor:
     arr = np.concatenate(
         [
-            np.array([obs["current_player"], obs["action_points"], obs["opponent_hand"]], dtype=np.float32),
+            np.array(
+                [
+                    obs["current_player"],
+                    obs["action_points"],
+                    obs["opponent_hand"],
+                ],
+                dtype=np.float32,
+            ),
             obs["board_owner"].astype(np.float32).flatten(),
             obs["board_health"].astype(np.float32).flatten(),
+            obs["unit_hand"].astype(np.float32).flatten(),
+            obs["spell_hand"].astype(np.float32).flatten(),
         ]
     )
     return torch.from_numpy(arr)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -6,6 +6,14 @@ from game_state import GameState
 from units import Warrior
 
 
+def test_observation_contains_hand_info():
+    env = GridsEnv()
+    obs, _ = env.reset()
+    assert "unit_hand" in obs and "spell_hand" in obs
+    assert len(obs["unit_hand"]) == 10
+    assert len(obs["spell_hand"]) == 10
+
+
 def test_deploy_action():
     env = GridsEnv()
     assert env.state.unit_hand


### PR DESCRIPTION
## Summary
- include unit and spell hands in environment observations
- encode hand values for the DQN agent
- test for new observation keys

## Testing
- `pytest -q`
- `python self_play.py > /tmp/self_play.log`

------
https://chatgpt.com/codex/tasks/task_e_684affb17e74832587cb0269c974b096