### PR TITLE
Improve environment efficiency

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -297,14 +297,28 @@ class GameState:
 
     # ---------- Helpers ----------
     def get_valid_move_squares(self, unit):
+        """Return all squares the given ``unit`` can reach this turn."""
+        directions = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+        queue = [(unit.row, unit.col, 0)]
+        visited = {(unit.row, unit.col)}
         valid_moves = []
-        for row in range(ROWS):
-            for col in range(COLUMNS):
-                if (row, col) == (unit.row, unit.col):
+
+        while queue:
+            row, col, dist = queue.pop(0)
+            if dist >= unit.move_range:
+                continue
+            for dr, dc in directions:
+                nr, nc = row + dr, col + dc
+                if not (0 <= nr < ROWS and 0 <= nc < COLUMNS):
                     continue
-                path = self.a_star_pathfinding((unit.row, unit.col), (row, col))
-                if path and len(path) <= unit.move_range:
-                    valid_moves.append((row, col))
+                if (nr, nc) in visited:
+                    continue
+                if any(u.row == nr and u.col == nc for u in self.units):
+                    continue
+                visited.add((nr, nc))
+                valid_moves.append((nr, nc))
+                queue.append((nr, nc, dist + 1))
+
         return valid_moves
 
     def get_attackable_units(self, unit):

--- a/grids_env.py
+++ b/grids_env.py
@@ -180,9 +180,15 @@ class GridsEnv(gym.Env):
             for r, c in self.state.get_valid_deploy_squares(player):
                 actions.append((1, idx, r, c))
         for idx, card in enumerate(self.state.spell_hands[player]):
-            for r in range(ROWS):
-                for c in range(COLUMNS):
-                    actions.append((2, idx, r, c))
+            target_cells = set()
+            for u in self.state.units:
+                for dr in (-1, 0, 1):
+                    for dc in (-1, 0, 1):
+                        r, c = u.row + dr, u.col + dc
+                        if 0 <= r < ROWS and 0 <= c < COLUMNS:
+                            target_cells.add((r, c))
+            for r, c in target_cells:
+                actions.append((2, idx, r, c))
 
         # drawing cards costs 1 action point and is only available when
         # the player has remaining AP and space in hand


### PR DESCRIPTION
## Summary
- use BFS rather than A* per cell when collecting reachable squares
- limit spell targeting to cells around existing units

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0214552483259870aa7c8bfe7e5d