### PR TITLE
Implement action enum and deque BFS

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -1,0 +1,11 @@
+from enum import IntEnum
+
+class ActionType(IntEnum):
+    """Enumeration of possible action types in the environment."""
+    MOVE = 0
+    DEPLOY = 1
+    PLAY_CARD = 2
+    END_TURN = 3
+    ATTACK = 4
+    DRAW_SPELL = 5
+    DRAW_UNIT = 6

--- a/agents.py
+++ b/agents.py
@@ -1,8 +1,14 @@
 import random
 from grids_env import GridsEnv
+from actions import ActionType
 
 class RandomAgent:
     """Agent that selects a random valid action."""
     def act(self, env: GridsEnv):
         actions = env.valid_actions()
-        return random.choice(actions) if actions else (2,0,0,0)
+        return random.choice(actions) if actions else (
+            ActionType.PLAY_CARD,
+            0,
+            0,
+            0,
+        )

--- a/dqn_agent.py
+++ b/dqn_agent.py
@@ -8,16 +8,19 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from grids_env import GridsEnv
+from actions import ActionType
 from constants import ROWS, COLUMNS
 
 # Size of the discrete action space. There are seven action types
 # (move, deploy, play card, end turn, attack, draw spell, draw unit) so the action space must account
 # for all of them.
-ACTION_SIZE = 7 * 20 * ROWS * COLUMNS
+# The action space includes one dimension for the ``ActionType`` enum
+ACTION_SIZE = len(ActionType) * 20 * ROWS * COLUMNS
 
 
 def action_to_index(action: Tuple[int, int, int, int]) -> int:
     atype, idx, row, col = action
+    atype = int(atype)
     return ((atype * 20 + idx) * ROWS + row) * COLUMNS + col
 
 
@@ -28,7 +31,7 @@ def index_to_action(index: int) -> Tuple[int, int, int, int]:
     index //= ROWS
     idx = index % 20
     atype = index // 20
-    return atype, idx, row, col
+    return ActionType(atype), idx, row, col
 
 
 def obs_to_tensor(obs: dict) -> torch.Tensor:

--- a/game_state.py
+++ b/game_state.py
@@ -1,5 +1,6 @@
 # Game state logic for grids environment
 import heapq
+from collections import deque
 import random
 from constants import ROWS, COLUMNS, CELL_SIZE, HAND_CAPACITY
 from units import (
@@ -299,12 +300,12 @@ class GameState:
     def get_valid_move_squares(self, unit):
         """Return all squares the given ``unit`` can reach this turn."""
         directions = [(-1, 0), (1, 0), (0, -1), (0, 1)]
-        queue = [(unit.row, unit.col, 0)]
+        queue = deque([(unit.row, unit.col, 0)])
         visited = {(unit.row, unit.col)}
         valid_moves = []
 
         while queue:
-            row, col, dist = queue.pop(0)
+            row, col, dist = queue.popleft()
             if dist >= unit.move_range:
                 continue
             for dr, dc in directions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+gym
+arcade
+torch
+pytest

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -2,6 +2,7 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import gym
 from grids_env import GridsEnv, UNIT_DEPLOY_REWARD, ATTACK_REWARD, DRAW_CARD_REWARD
+from actions import ActionType
 from game_state import GameState
 from units import Warrior
 
@@ -18,7 +19,7 @@ def test_deploy_action():
     env = GridsEnv()
     assert env.state.unit_hand
     square = env.state.get_valid_deploy_squares()[0]
-    action = (1, 0, square[0], square[1])
+    action = (ActionType.DEPLOY, 0, square[0], square[1])
     obs, reward, term, trunc, _ = env.step(action)
     assert reward == 1.0 + UNIT_DEPLOY_REWARD
     assert any(u.row == square[0] and u.col == square[1] for u in env.state.units)
@@ -42,7 +43,7 @@ def test_env_terminates_when_commander_dies():
     env.state.units.append(attacker)
     commander.health = 1
     env.state.attack_unit(attacker, commander)
-    obs, reward, term, trunc, _ = env.step((3, 0, 0, 0))
+    obs, reward, term, trunc, _ = env.step((ActionType.END_TURN, 0, 0, 0))
     assert term
     assert env.state.winner == 1
 
@@ -50,7 +51,7 @@ def test_env_terminates_when_commander_dies():
 def test_play_card_action():
     env = GridsEnv()
     assert env.state.spell_hand
-    action = (2, 0, 0, 0)
+    action = (ActionType.PLAY_CARD, 0, 0, 0)
     obs, reward, term, trunc, _ = env.step(action)
     assert reward >= 1.0
 
@@ -62,7 +63,7 @@ def test_attack_action():
     target = Warrior(0, 1, owner=2)
     env.state.units = [attacker, target]
     env.state.current_player = 1
-    action = (4, 0, target.row, target.col)
+    action = (ActionType.ATTACK, 0, target.row, target.col)
     obs, reward, term, trunc, _ = env.step(action)
     assert reward == 1.0 + ATTACK_REWARD
     assert target.health < target.max_health
@@ -72,7 +73,7 @@ def test_draw_spell_action():
     env = GridsEnv()
     hand_before = len(env.state.spell_hand)
     ap_before = env.state.current_action_points
-    action = (5, 0, 0, 0)
+    action = (ActionType.DRAW_SPELL, 0, 0, 0)
     obs, reward, term, trunc, _ = env.step(action)
     assert len(env.state.spell_hand) == hand_before + 1
     assert env.state.current_action_points == ap_before - 1


### PR DESCRIPTION
## Summary
- add an `ActionType` enum for all environment actions
- use `collections.deque` for move range search
- switch environment and tests to the new enum
- expose enum length in DQN agent
- include requirements file

## Testing
- `pip install gym==0.26.2 arcade==2.6.17 torch==2.3.0 --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b06e308d08325931f77a179fd86f0