### PR TITLE
Remove base reward for valid actions

### DIFF
--- a/grids_env.py
+++ b/grids_env.py
@@ -104,7 +104,7 @@ class GridsEnv(gym.Env):
                 return self._get_obs(), -1.0, True, False, {}
             unit = self.state.units[idx]
             ok = self.state.move_unit(unit, row, col, animate=self.animate)
-            reward = 1.0 if ok else -1.0
+            reward = 0.0 if ok else -1.0
         elif action_type == ActionType.DEPLOY:
             if idx >= len(self.state.unit_hand):
                 return self._get_obs(), -1.0, True, False, {}
@@ -112,7 +112,7 @@ class GridsEnv(gym.Env):
             if (row, col) not in self.state.get_valid_deploy_squares():
                 return self._get_obs(), -1.0, True, False, {}
             unit = self.state.place_unit(unit_cls, row, col)
-            reward = 1.0 if unit else -1.0
+            reward = 0.0 if unit else -1.0
             if unit:
                 reward += UNIT_DEPLOY_REWARD
         elif action_type == ActionType.PLAY_CARD:
@@ -120,7 +120,7 @@ class GridsEnv(gym.Env):
                 return self._get_obs(), -1.0, True, False, {}
             card = self.state.spell_hand[idx]
             ok = self.state.play_card(card, (row, col))
-            reward = 1.0 if ok else -1.0
+            reward = 0.0 if ok else -1.0
             if ok:
                 reward += ITEM_USE_REWARD
         elif action_type == ActionType.ATTACK:
@@ -131,7 +131,7 @@ class GridsEnv(gym.Env):
             if target is None:
                 return self._get_obs(), -1.0, True, False, {}
             ok = self.state.attack_unit(attacker, target)
-            reward = 1.0 if ok else -1.0
+            reward = 0.0 if ok else -1.0
             if ok:
                 reward += ATTACK_REWARD
         elif action_type == ActionType.DRAW_SPELL:
@@ -139,7 +139,7 @@ class GridsEnv(gym.Env):
             ok = self.state.draw_cards(
                 self.state.spell_deck, self.state.current_player, num=1, ap_cost=1
             )
-            reward = 1.0 if ok else -1.0
+            reward = 0.0 if ok else -1.0
             if ok and len(self.state.spell_hand) > before:
                 reward += DRAW_CARD_REWARD
         elif action_type == ActionType.DRAW_UNIT:
@@ -147,7 +147,7 @@ class GridsEnv(gym.Env):
             ok = self.state.draw_cards(
                 self.state.unit_deck, self.state.current_player, num=1, ap_cost=1
             )
-            reward = 1.0 if ok else -1.0
+            reward = 0.0 if ok else -1.0
             if ok and len(self.state.unit_hand) > before:
                 reward += DRAW_CARD_REWARD
         elif action_type == ActionType.END_TURN:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,13 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import gym
-from grids_env import GridsEnv, UNIT_DEPLOY_REWARD, ATTACK_REWARD, DRAW_CARD_REWARD
+from grids_env import (
+    GridsEnv,
+    UNIT_DEPLOY_REWARD,
+    ATTACK_REWARD,
+    DRAW_CARD_REWARD,
+    ITEM_USE_REWARD,
+)
 from actions import ActionType
 from game_state import GameState
 from units import Warrior
@@ -21,7 +27,7 @@ def test_deploy_action():
     square = env.state.get_valid_deploy_squares()[0]
     action = (ActionType.DEPLOY, 0, square[0], square[1])
     obs, reward, term, trunc, _ = env.step(action)
-    assert reward == 1.0 + UNIT_DEPLOY_REWARD
+    assert reward == UNIT_DEPLOY_REWARD
     assert any(u.row == square[0] and u.col == square[1] for u in env.state.units)
     assert not term and not trunc
 
@@ -53,7 +59,7 @@ def test_play_card_action():
     assert env.state.spell_hand
     action = (ActionType.PLAY_CARD, 0, 0, 0)
     obs, reward, term, trunc, _ = env.step(action)
-    assert reward >= 1.0
+    assert reward >= ITEM_USE_REWARD
 
 
 def test_attack_action():
@@ -65,7 +71,7 @@ def test_attack_action():
     env.state.current_player = 1
     action = (ActionType.ATTACK, 0, target.row, target.col)
     obs, reward, term, trunc, _ = env.step(action)
-    assert reward == 1.0 + ATTACK_REWARD
+    assert reward == ATTACK_REWARD
     assert target.health < target.max_health
 
 
@@ -77,5 +83,5 @@ def test_draw_spell_action():
     obs, reward, term, trunc, _ = env.step(action)
     assert len(env.state.spell_hand) == hand_before + 1
     assert env.state.current_action_points == ap_before - 1
-    assert reward == 1.0 + DRAW_CARD_REWARD
+    assert reward == DRAW_CARD_REWARD
 


### PR DESCRIPTION
## Summary
- adjust `grids_env` to not add a base reward when an action succeeds
- update env tests to use the new reward scheme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0e3787d88325b1af9a6793835129