### PR TITLE
Log attack actions and silence fire message

### DIFF
--- a/cards.py
+++ b/cards.py
@@ -24,7 +24,6 @@ class Fireball(Card):
             print(f"{target.unit_type} hit by Fireball! New health: {target.health}")
         else:
             row, col = target
-            print("Fireball played on grid cell", target)
         game.fires[(row, col)] = 4
 
 class Freeze(Card):

--- a/game_state.py
+++ b/game_state.py
@@ -223,6 +223,9 @@ class GameState:
             if attacker.owner == target.owner:
                 # Heal friendly target up to its maximum health
                 target.health = min(target.health + attacker.attack, target.max_health)
+                print(
+                    f"{attacker.unit_type} heals {target.unit_type}! {target.unit_type} health is now {target.health}."
+                )
                 return True
             else:
                 # Healers cannot damage enemies
@@ -231,6 +234,9 @@ class GameState:
         if target.health <= 0:
             return
         target.health -= attacker.attack
+        print(
+            f"{attacker.unit_type} attacks {target.unit_type}! {target.unit_type} health is now {target.health}."
+        )
         if target.health <= 0:
             # remove defeated unit immediately so its cell becomes free and
             # check if the game has been won.


### PR DESCRIPTION
## Summary
- log attack and heal actions in `GameState.attack_unit`
- remove `Fireball` printout when used on an empty cell

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_684b11daf14c83259ef522a60beb562e