### PR TITLE
Adjust trebuchet attack mechanics

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -215,6 +215,9 @@ class GameState:
         if attacker.frozen_turns > 0:
             return False
 
+        if attacker.unit_type == "Trebuchet" and attacker.has_attacked:
+            return False
+
 
         if target in attacker.attacked_targets:
             return False
@@ -233,7 +236,11 @@ class GameState:
               
         if target.health <= 0:
             return
-        target.health -= attacker.attack
+        dist = self.manhattan_distance((attacker.row, attacker.col), (target.row, target.col))
+        damage = attacker.attack
+        if attacker.unit_type == "Trebuchet" and dist == 1:
+            damage = attacker.attack // 2
+        target.health -= damage
         print(
             f"{attacker.unit_type} attacks {target.unit_type}! {target.unit_type} health is now {target.health}."
         )
@@ -329,6 +336,8 @@ class GameState:
         return valid_moves
 
     def get_attackable_units(self, unit):
+        if unit.unit_type == "Trebuchet" and unit.has_attacked:
+            return []
         targets = []
         for other in self.units:
             if unit.unit_type == "Healer":

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -13,7 +13,7 @@ from grids import (
     Teleport,
 )
 from game_state import GameState
-from units import Warrior, Healer
+from units import Warrior, Healer, Trebuchet
 
 @pytest.fixture
 def game():
@@ -169,3 +169,31 @@ def test_teleport_spell_no_selection(game):
         for u in game.units
     )
     assert game.current_action_points == starting_ap - teleport.cost
+
+
+def test_trebuchet_attacks_only_once_per_turn():
+    state = GameState()
+    state.units = []
+    treb = Trebuchet(0, 0, owner=1)
+    enemy1 = Warrior(0, 2, owner=2)
+    enemy2 = Warrior(0, 3, owner=2)
+    state.units = [treb, enemy1, enemy2]
+
+    assert state.attack_unit(treb, enemy1)
+    assert not state.attack_unit(treb, enemy2)
+
+    state.end_turn()
+    state.end_turn()
+
+    assert state.attack_unit(treb, enemy2)
+
+
+def test_trebuchet_adjacent_half_damage():
+    state = GameState()
+    state.units = []
+    treb = Trebuchet(0, 0, owner=1)
+    enemy = Warrior(0, 1, owner=2)
+    state.units = [treb, enemy]
+    before = enemy.health
+    state.attack_unit(treb, enemy)
+    assert before - enemy.health == treb.attack // 2


### PR DESCRIPTION
## Summary
- limit trebuchet to one attack each turn
- halve trebuchet damage when attacking adjacent targets
- add regression tests for trebuchet restrictions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b184061e88325be038790ae7a9f7a